### PR TITLE
Stop modifying MTU

### DIFF
--- a/command_template/VyOS/bgp/bgp_refelence
+++ b/command_template/VyOS/bgp/bgp_refelence
@@ -1,6 +1,4 @@
 configure
-sudo /sbin/ifconfig eth0 mtu 1450
-sudo /sbin/ifconfig eth1 mtu 1450
 set protocols static route {{have_addr1}} blackhole distance 1
 set protocols static route {{have_addr2}} blackhole distance 1
 set protocols static route {{have_addr3}} blackhole distance 1

--- a/command_template/VyOS/bgp/bgp_target
+++ b/command_template/VyOS/bgp/bgp_target
@@ -1,6 +1,4 @@
 configure
-sudo /sbin/ifconfig eth0 mtu 1450
-sudo /sbin/ifconfig eth1 mtu 1450
 set protocols static route {{have_addr1}} blackhole distance 1
 set protocols static route {{have_addr2}} blackhole distance 1
 set protocols static route {{have_addr3}} blackhole distance 1

--- a/command_template/VyOS/ospf/ospf_reference
+++ b/command_template/VyOS/ospf/ospf_reference
@@ -1,6 +1,4 @@
 configure
-sudo /sbin/ifconfig eth0 mtu 1450
-sudo /sbin/ifconfig eth1 mtu 1450
 export D_PLANE_NIC_NAME=`/sbin/ifconfig | grep '{{macaddress}}' | awk '{print $1}'`
 env | grep D_PLANE_NIC_NAME
 set interfaces loopback lo address {{router_id}}/24

--- a/command_template/VyOS/ospf/ospf_target
+++ b/command_template/VyOS/ospf/ospf_target
@@ -1,6 +1,4 @@
 configure
-sudo /sbin/ifconfig eth0 mtu 1450
-sudo /sbin/ifconfig eth1 mtu 1450
 export D_PLANE_NIC_NAME=`/sbin/ifconfig | grep '{{macaddress}}' | awk '{print $1}'`
 env | grep D_PLANE_NIC_NAME
 set interfaces loopback lo address {{router_id}}/24


### PR DESCRIPTION
MTU is usually set via DHCP (Neutron) and 1450 can be inappropriate or
even wrong depending on the overlay (GENEVE).

Co-Authored-By: Thierry ALLENO <thierry.alleno@orange.com>

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>